### PR TITLE
feat: add CalculateOuts for computing poker outs

### DIFF
--- a/cards.go
+++ b/cards.go
@@ -10,7 +10,7 @@ func EvaluateEquity(players []Player) ([]float64, error) {
 
 	for _, p := range players {
 		for _, c := range p.Hand {
-			deck.removeCard(c)
+			deck.RemoveCard(c)
 		}
 	}
 

--- a/constants.go
+++ b/constants.go
@@ -256,7 +256,7 @@ func (d *Deck) DrawCards(n int) []Card {
 	return cards
 }
 
-func (d *Deck) removeCard(card Card) bool {
+func (d *Deck) RemoveCard(card Card) bool {
 	for i, c := range d.Cards {
 		if c.Rank == card.Rank && c.Suit == card.Suit {
 			d.Cards = append(d.Cards[:i], d.Cards[i+1:]...)

--- a/outs.go
+++ b/outs.go
@@ -1,0 +1,62 @@
+package poker
+
+import "fmt"
+
+// CalculateOuts returns the cards from the remaining deck that would
+// improve the hand type of the given hole cards + board combination.
+// holeCards must be exactly 2 cards. board must be 3, 4, or 5 cards.
+// Returns the list of out cards and their count.
+func CalculateOuts(holeCards []Card, board []Card) ([]Card, error) {
+	if len(holeCards) != 2 {
+		return nil, fmt.Errorf("holeCards must be exactly 2 cards, got %d", len(holeCards))
+	}
+	if len(board) < 3 || len(board) > 5 {
+		return nil, fmt.Errorf("board must be 3, 4, or 5 cards, got %d", len(board))
+	}
+
+	if len(board) == 5 {
+		return nil, nil
+	}
+
+	baseCards := make([]Card, len(holeCards)+len(board))
+	copy(baseCards, holeCards)
+	copy(baseCards[len(holeCards):], board)
+
+	currentType := evaluateHandType(baseCards)
+
+	deck := NewDeck()
+	for _, c := range holeCards {
+		deck.RemoveCard(c)
+	}
+	for _, c := range board {
+		deck.RemoveCard(c)
+	}
+
+	var outs []Card
+	candidateCards := make([]Card, len(baseCards)+1)
+
+	for _, card := range deck.Cards {
+		copy(candidateCards, baseCards)
+		candidateCards[len(baseCards)] = card
+		candidateType := evaluateHandType(candidateCards)
+		if candidateType > currentType {
+			outs = append(outs, card)
+		}
+	}
+
+	return outs, nil
+}
+
+// evaluateHandType returns the HandType for the given cards.
+// Uses NewBestMadeHand for 7-card hands (O(1) lookup table),
+// and falls back to evaluate() for other card counts.
+// evaluate() modifies slices in place, so a copy is made to protect the caller.
+func evaluateHandType(cards []Card) HandType {
+	if len(cards) == 7 {
+		return NewBestMadeHand(cards).Type()
+	}
+	cardsCopy := make([]Card, len(cards))
+	copy(cardsCopy, cards)
+	handType, _, _ := evaluate(cardsCopy)
+	return handType
+}

--- a/outs_test.go
+++ b/outs_test.go
@@ -1,0 +1,201 @@
+package poker
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCalculateOuts(t *testing.T) {
+	tests := []struct {
+		name         string
+		holeCards    []Card
+		board        []Card
+		wantCount    int
+		wantCards    []Card
+		wantContains []Card
+		wantErr      bool
+	}{
+		{
+			name: "flush draw from straight - 9 outs (only flush/straight-flush improve)",
+			holeCards: []Card{
+				{RankFive, Hearts},
+				{RankSix, Hearts},
+			},
+			board: []Card{
+				{RankSeven, Hearts},
+				{RankEight, Hearts},
+				{RankNine, Clubs},
+			},
+			wantCount: 9,
+		},
+		{
+			name: "open-ended straight draw from high card - includes pair outs",
+			holeCards: []Card{
+				{RankEight, Hearts},
+				{RankNine, Clubs},
+			},
+			board: []Card{
+				{RankSeven, Diamonds},
+				{RankSix, Spades},
+				{RankDeuce, Hearts},
+			},
+			wantCount: 23,
+			wantContains: []Card{
+				{RankFive, Hearts},
+				{RankFive, Clubs},
+				{RankFive, Diamonds},
+				{RankFive, Spades},
+				{RankTen, Hearts},
+				{RankTen, Clubs},
+				{RankTen, Diamonds},
+				{RankTen, Spades},
+			},
+		},
+		{
+			name: "pocket pair - two pair and set outs",
+			holeCards: []Card{
+				{RankJack, Hearts},
+				{RankJack, Clubs},
+			},
+			board: []Card{
+				{RankDeuce, Diamonds},
+				{RankFive, Spades},
+				{RankNine, Hearts},
+			},
+			wantCount: 11,
+			wantContains: []Card{
+				{RankJack, Diamonds},
+				{RankJack, Spades},
+			},
+		},
+		{
+			name: "turn flush draw from straight - 9 outs (uses NewBestMadeHand for 7 cards)",
+			holeCards: []Card{
+				{RankFive, Hearts},
+				{RankSix, Hearts},
+			},
+			board: []Card{
+				{RankSeven, Hearts},
+				{RankEight, Hearts},
+				{RankNine, Clubs},
+				{RankKing, Diamonds},
+			},
+			wantCount: 9,
+		},
+		{
+			name: "royal flush - no outs",
+			holeCards: []Card{
+				{RankAce, Spades},
+				{RankKing, Spades},
+			},
+			board: []Card{
+				{RankQueen, Spades},
+				{RankJack, Spades},
+				{RankTen, Spades},
+			},
+		},
+		{
+			name: "river board 5 cards - no outs",
+			holeCards: []Card{
+				{RankAce, Hearts},
+				{RankKing, Hearts},
+			},
+			board: []Card{
+				{RankDeuce, Clubs},
+				{RankThree, Diamonds},
+				{RankFour, Spades},
+				{RankSeven, Hearts},
+				{RankNine, Clubs},
+			},
+		},
+		{
+			name: "invalid hole cards - 1 card",
+			holeCards: []Card{
+				{RankAce, Hearts},
+			},
+			board: []Card{
+				{RankDeuce, Clubs},
+				{RankThree, Diamonds},
+				{RankFour, Spades},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid board - 6 cards",
+			holeCards: []Card{
+				{RankAce, Hearts},
+				{RankKing, Hearts},
+			},
+			board: []Card{
+				{RankDeuce, Clubs},
+				{RankThree, Diamonds},
+				{RankFour, Spades},
+				{RankFive, Hearts},
+				{RankSix, Clubs},
+				{RankSeven, Diamonds},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid board - 2 cards",
+			holeCards: []Card{
+				{RankAce, Hearts},
+				{RankKing, Hearts},
+			},
+			board: []Card{
+				{RankDeuce, Clubs},
+				{RankThree, Diamonds},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CalculateOuts(tt.holeCards, tt.board)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != tt.wantCount {
+				t.Errorf("outs count = %d, want %d", len(got), tt.wantCount)
+			}
+
+			if tt.wantCards != nil {
+				if diff := cmp.Diff(tt.wantCards, got); diff != "" {
+					t.Errorf("outs mismatch (-want +got):\n%s", diff)
+				}
+			}
+
+			for _, wc := range tt.wantContains {
+				if !slices.Contains(got, wc) {
+					t.Errorf("expected outs to contain %v", wc)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCalculateOuts(b *testing.B) {
+	holeCards := []Card{
+		{RankFive, Hearts},
+		{RankSix, Hearts},
+	}
+	board := []Card{
+		{RankSeven, Hearts},
+		{RankEight, Hearts},
+		{RankNine, Clubs},
+	}
+
+	for b.Loop() {
+		_, _ = CalculateOuts(holeCards, board)
+	}
+}

--- a/porting_compare.go
+++ b/porting_compare.go
@@ -8,7 +8,7 @@ import (
 func CompareVSMadeHand(p1 Player) error {
 	deck := NewDeck()
 	for _, c := range p1.Hand {
-		deck.removeCard(c)
+		deck.RemoveCard(c)
 	}
 
 	for _, board := range AllCombinations(deck.Cards, 5) {
@@ -37,12 +37,12 @@ func EvaluateEquityByMadeHandWithCommunity(players []Player, community []Card) (
 
 	for _, p := range players {
 		for _, c := range p.Hand {
-			deck.removeCard(c)
+			deck.RemoveCard(c)
 		}
 	}
 
 	for _, c := range community {
-		deck.removeCard(c)
+		deck.RemoveCard(c)
 	}
 
 	wins := make([]int, len(players))


### PR DESCRIPTION
## Summary
- Add `CalculateOuts(holeCards, board)` function that computes which remaining deck cards would improve the hand type
- Export `Deck.RemoveCard` (previously unexported `removeCard`) for public use
- Add `evaluateHandType` helper that uses `NewBestMadeHand` (O(1) lookup) for 7-card hands and `evaluate()` for 5-6 card hands

## Changes
- `outs.go` — New `CalculateOuts` function and `evaluateHandType` helper
- `outs_test.go` — 8 test cases (flush draw, OESD, pocket pair, royal flush, river, invalid inputs) + benchmark
- `constants.go` — `removeCard` → `RemoveCard` (export)
- `cards.go`, `porting_compare.go` — Update callers to use `RemoveCard`

## Design Notes
- `NewBestMadeHand` only works correctly with exactly 7 cards (lookup table is built for 7-card evaluation). For flop (5 cards) and turn (6 cards), the internal `evaluate()` function is used with a defensive copy to prevent in-place slice mutation from corrupting caller data.
- Outs are defined as cards that improve `HandType` (e.g., High Card → Pair, Pair → Two Pair). Same-type kicker improvements are excluded.
- Benchmark: ~68μs/op on Apple M1 Max

## Test Plan
- `go test -v -run TestCalculateOuts ./...`
- `go test -bench=BenchmarkCalculateOuts -benchmem ./...`
- All existing tests pass unchanged