### PR TITLE
ci: bump Go, dependencies, and GitHub Actions versions

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: './go.mod'
       # Run benchmark with `go test -bench` and stores the output to a file
@@ -20,7 +20,7 @@ jobs:
           go test -bench . | tee output.txt
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -9,8 +9,8 @@ jobs:
     name: Performance regression check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: './go.mod'
       # Run benchmark with `go test -bench` and stores the output to a file
@@ -20,13 +20,13 @@ jobs:
           go test -bench . | tee output.txt
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark
       # Run `github-action-benchmark` action
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@a7bc2366eda11037936ea57d811a43b3418d3073 # v1.21.0
         with:
           # What benchmark tool the output.txt came from
           tool: 'go'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,17 +9,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
       - name: Test
         run: |
           cd ui/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,19 +9,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
       - name: Lint
-        run: |
-          go install honnef.co/go/tools/cmd/staticcheck@latest
-          staticcheck ./...
+        uses: golangci/golangci-lint-action@v7
       - name: Test
         run: |
           cd ui/

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/whywaita/poker-go
 
-go 1.20
+go 1.26
 
-require github.com/google/go-cmp v0.5.9 // indirect
+require github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=


### PR DESCRIPTION
## Summary
- Bump Go version from 1.20 to 1.26
- Update all GitHub Actions to latest major versions
- Replace staticcheck with golangci-lint
- Update go-cmp to v0.7.0 as a direct dependency

## Changes
- **go.mod**: `go 1.20` → `go 1.26`, `go-cmp v0.5.9 // indirect` → `v0.7.0` (direct)
- **test.yaml**: `actions/checkout@v3` → `v4`, `actions/setup-go@v4` → `v5`, `actions/setup-node@v3` → `v4` (Node 16 → 20), staticcheck → `golangci/golangci-lint-action@v7`
- **benchmark.yaml**: `actions/setup-go@v4` → `v5`, `actions/cache@v1` → `v4`

## Test Plan
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Verify GitHub Actions CI passes on this PR

## Notes
- Node.js version in test workflow updated from 16 (EOL) to 20 (LTS)
- go-cmp was marked `// indirect` despite being directly imported in test files; now correctly listed as a direct dependency