### PR TITLE
fix: correct tie handling in EvaluateEquityByMadeHandWithCommunity

### DIFF
--- a/porting_compare.go
+++ b/porting_compare.go
@@ -45,31 +45,27 @@ func EvaluateEquityByMadeHandWithCommunity(players []Player, community []Card) (
 		deck.RemoveCard(c)
 	}
 
-	wins := make([]int, len(players))
-
-	var ties int
+	shares := make([]float64, len(players))
 	var total int
 	for _, board := range AllCombinations(deck.Cards, 5-len(community)) {
 		winners, err := CompareHandsByMadeHand(players, append(community, board...))
 		if err != nil {
 			return nil, err
 		}
-		switch {
-		case len(winners) == len(players):
-			ties++
-		default:
-			for _, winner := range winners {
-				wins[indexOf(winner, players)] += 1
-			}
+		if len(winners) == 0 {
+			total++
+			continue
+		}
+		share := 1.0 / float64(len(winners))
+		for _, winner := range winners {
+			shares[indexOf(winner, players)] += share
 		}
 		total++
 	}
 
-	equities := make([]float64, 0, len(players))
-	baseTies := ties / len(players)
-
-	for _, win := range wins {
-		equities = append(equities, float64(win+baseTies)/float64(total))
+	equities := make([]float64, len(players))
+	for i, s := range shares {
+		equities[i] = s / float64(total)
 	}
 
 	return equities, nil

--- a/porting_compare_test.go
+++ b/porting_compare_test.go
@@ -134,8 +134,8 @@ func TestEvaluateEquityByMadeHand(t *testing.T) {
 				},
 			},
 			want: []float64{
-				0.12031274820359002,
-				0.8796866677879629,
+				0.12031304020781357,
+				0.8796869597921865,
 			},
 		},
 		{
@@ -164,9 +164,9 @@ func TestEvaluateEquityByMadeHand(t *testing.T) {
 				},
 			},
 			want: []float64{
-				0.08533040939512122,
-				0.6633188741378833,
-				0.2513507164669955,
+				0.08533040939511266,
+				0.6633188741379331,
+				0.25135071646699475,
 			},
 		},
 	}
@@ -284,8 +284,8 @@ func TestEvaluateEquityByMadeHandWithCommunity(t *testing.T) {
 				},
 			},
 			want: []float64{
-				0,
-				0,
+				0.5,
+				0.5,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Fix integer-division bug in tie handling of `EvaluateEquityByMadeHandWithCommunity`
- On the river, a chopped pot (all players have the same hand) gave every player equity 0 instead of splitting evenly
- Partial ties (some but not all players tying for the win) also gave each winner a full win credit, making the equity sum exceed 1.0

### Root cause

`baseTies := ties / len(players)` is integer division, which truncates to 0 when `ties < len(players)`. On the river there is exactly one board evaluation, so a tie yields `ties=1` / `len(players)=2` = `0`, making all equities 0.

### Fix

Replace the separate `wins` (int) / `ties` (int) counters with a single `shares` (float64) slice. Each board's winners receive `1/len(winners)`, correctly handling both complete and partial ties.

## Test plan

- [x] Update existing test expectations to correct values
- [x] River chop case: [0, 0] → [0.5, 0.5]
- [x] Preflop equities: sum now closer to exactly 1.0
- [x] `go test ./...` all pass