### PR TITLE
Add duplicate card validation to Evaluate()

### DIFF
--- a/cards.go
+++ b/cards.go
@@ -45,9 +45,17 @@ func EvaluateEquity(players []Player) ([]float64, error) {
 }
 
 // Evaluate returns the best hand type and cards for the given cards.
+// The cards slice must contain exactly 7 unique cards (no duplicates).
 func Evaluate(cards []Card) (HandType, []Card, error) {
 	if len(cards) != 7 {
 		return 0, nil, fmt.Errorf("invalid number of cards")
+	}
+	seen := make(map[Card]bool, 7)
+	for _, c := range cards {
+		if seen[c] {
+			return 0, nil, fmt.Errorf("duplicate card: %s", c)
+		}
+		seen[c] = true
 	}
 	return evaluate(cards)
 }

--- a/cards_test.go
+++ b/cards_test.go
@@ -236,6 +236,23 @@ func TestEvaluate(t *testing.T) {
 	}
 }
 
+func TestEvaluateDuplicateCards(t *testing.T) {
+	input := []poker.Card{
+		{Rank: poker.RankAce, Suit: poker.Hearts},
+		{Rank: poker.RankKing, Suit: poker.Hearts},
+		{Rank: poker.RankAce, Suit: poker.Clubs},
+		{Rank: poker.RankAce, Suit: poker.Spades},
+		{Rank: poker.RankKing, Suit: poker.Hearts}, // duplicate of index 1
+		{Rank: poker.RankFour, Suit: poker.Hearts},
+		{Rank: poker.RankJack, Suit: poker.Hearts},
+	}
+
+	_, _, err := poker.Evaluate(input)
+	if err == nil {
+		t.Error("expected error for duplicate cards, got nil")
+	}
+}
+
 func TestEvaluateEquity(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

`Evaluate()` now validates that the 7 input cards are unique before evaluating the hand. Previously, duplicate cards (e.g., the same card appearing in both a player's hand and the board) would silently produce incorrect results.

## Changes

- Add a `map[Card]bool` check at the top of `Evaluate()` to detect duplicate cards
- Return an error with the offending card when duplicates are found
- Add `TestEvaluateDuplicateCards` to verify the error case

## Example

Before — silently returns `Full House` with two K♥:
```go
h1 := []poker.Card{
    {Rank: poker.RankAce, Suit: poker.Hearts},
    {Rank: poker.RankKing, Suit: poker.Hearts},
}
board := []poker.Card{
    {Rank: poker.RankAce, Suit: poker.Clubs},
    {Rank: poker.RankAce, Suit: poker.Spades},
    {Rank: poker.RankKing, Suit: poker.Hearts}, // duplicate!
    {Rank: poker.RankFour, Suit: poker.Hearts},
    {Rank: poker.RankJack, Suit: poker.Hearts},
}
// handtype: Full House, cards: [A hearts A clubs A spades K hearts K hearts]
```

After — returns an error:
```
duplicate card: K hearts
```

Fixes #11